### PR TITLE
Enhance experiment scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# FIG-AI-Preferences
+# FIG-AI Preferences
+
+This repository contains scaffolding for experiments investigating the stability
+of preferences elicited from language models. The work draws on two proposals
+for testing context-invariance using lottery-certainty equivalents and
+contextual bandit tasks.
+
+## Repository layout
+
+```
+src/fig_preferences/   Python package with environments and utilities
+experiments/           Example scripts and configs
+data/                  World states and prompt specifications
+preregistration.md     Outline of hypotheses and analysis plan
+requirements.txt       Python package requirements
+```
+
+## Getting started
+
+1. Install dependencies
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run a simple bandit experiment using the config file
+   ```bash
+  python experiments/run_experiment.py experiments/config/bandit_example.yaml
+   ```
+
+Additional example scripts `run_bandit_money.py` and `run_bandit_outcome.py`
+demonstrate the underlying bandit environment.
+
+The experiment code is intentionally minimal at this stage. It is intended as a
+starting point for implementing the full design described in the proposals.

--- a/data/prompts/sample_prompts.yml
+++ b/data/prompts/sample_prompts.yml
@@ -1,0 +1,14 @@
+# Sample prompt specification for prompt factory
+randomisation_axes:
+  scale_length: [5, 7]
+  option_order: [original, shuffled]
+  response_format: [letter, number]
+  persona_frame: [assistant, critic, user-simulator]
+  require_reasoning: [true, false]
+
+# Example prompts for lottery CE phase
+lottery_prompts:
+  - state: eat an apple
+    text: "How desirable is it to eat an apple?"
+  - state: watch a movie
+    text: "How desirable is it to watch a movie?"

--- a/data/world_states.json
+++ b/data/world_states.json
@@ -1,0 +1,7 @@
+[
+  "eat an apple",
+  "watch a movie",
+  "take a walk",
+  "read a book",
+  "cook dinner"
+]

--- a/experiments/config/bandit_example.yaml
+++ b/experiments/config/bandit_example.yaml
@@ -1,0 +1,5 @@
+# Example configuration for running a bandit experiment
+world_states_file: data/world_states.json
+utilities: [1.0, 0.8, 0.5, 0.3, 0.2]
+noise_after: 5
+noise_std: 0.1

--- a/experiments/run_bandit_money.py
+++ b/experiments/run_bandit_money.py
@@ -1,0 +1,28 @@
+"""Example script for the money-based bandit task."""
+
+import sys
+from pathlib import Path
+
+# Allow running without installing the package
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from fig_preferences.bandits import DeterministicBandit
+from fig_preferences.prompt_factory import PromptFactory
+
+
+def main():
+    rewards = [1.0, 0.5, 0.2]
+    bandit = DeterministicBandit(rewards, noise_after=5, noise_std=0.1)
+    factory = PromptFactory.from_yaml("data/prompts/sample_prompts.yml")
+
+    for step in range(3):
+        arm = step % len(rewards)
+        prompt = factory.sample_prompt(f"option {arm}")
+        reward = bandit.step(arm)
+        print(f"{prompt} -> reward {reward:.2f}")
+
+    print("Pull distribution", bandit.pull_distribution)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/run_bandit_outcome.py
+++ b/experiments/run_bandit_outcome.py
@@ -1,0 +1,27 @@
+"""Example script for the outcome-only bandit task."""
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from fig_preferences.bandits import DeterministicBandit
+from fig_preferences.prompt_factory import PromptFactory
+
+
+def main():
+    outcomes = ["eat an apple", "watch a movie", "take a walk"]
+    bandit = DeterministicBandit([1.0, 0.5, 0.2], noise_after=5, noise_std=0.1)
+    factory = PromptFactory.from_yaml("data/prompts/sample_prompts.yml")
+
+    for step in range(3):
+        arm = step % len(outcomes)
+        prompt = factory.sample_prompt(outcomes[arm])
+        reward = bandit.step(arm)
+        print(f"{prompt} -> {reward:.2f}")
+
+    print("Pull distribution", bandit.pull_distribution)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/run_experiment.py
+++ b/experiments/run_experiment.py
@@ -1,0 +1,46 @@
+"""Run a simple bandit experiment using a YAML config."""
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from fig_preferences.bandits import DeterministicBandit
+from fig_preferences.prompt_factory import PromptFactory
+
+
+def load_config(path: Path) -> dict:
+    import yaml
+    with open(path, "r") as f:
+        return yaml.safe_load(f)
+
+
+def run_bandit(config_path: Path) -> None:
+    cfg = load_config(config_path)
+    with open(cfg["world_states_file"], "r") as f:
+        states = json.load(f)
+    utilities = cfg.get("utilities", [1.0] * len(states))
+    bandit = DeterministicBandit(utilities, noise_after=cfg.get("noise_after"), noise_std=cfg.get("noise_std", 0.0))
+
+    factory = PromptFactory.from_yaml("data/prompts/sample_prompts.yml")
+
+    for step in range(len(states)):
+        arm = step % len(states)
+        prompt = factory.sample_prompt(states[arm])
+        reward = bandit.step(arm)
+        print(f"{prompt} -> reward {reward:.2f}")
+
+    print("Pull distribution", bandit.pull_distribution)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("config", type=Path, help="Path to config YAML")
+    args = parser.parse_args()
+    run_bandit(args.config)
+
+
+if __name__ == "__main__":
+    main()

--- a/preregistration.md
+++ b/preregistration.md
@@ -1,0 +1,22 @@
+# Preregistration Overview
+
+This document outlines the key hypotheses and analysis plan for the initial experiments
+on preference elicitation in language models. The goal is to test whether utilities
+elicited in a lottery setting remain stable across contextual bandit tasks.
+
+## Hypotheses
+
+1. Utilities inferred from lottery prompts yield consistent choices in a money-based bandit.
+2. The same utilities transfer to outcome-only bandits with total-variation distance (TVD)
+   below 0.05.
+3. Learning efficiency, measured by cumulative regret, is comparable between money and
+   outcome bandits.
+
+## Analysis Plan
+
+Paired bootstrap confidence intervals will be computed for TVD and Jensen-Shannon
+divergence between arm pull distributions. Results will be compared across base and
+RLHF models.
+
+All prompts and random seeds will be logged to SQLite and uploaded to Weights & Biases
+for transparency.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# Core dependencies
+PyYAML
+numpy
+pandas
+matplotlib

--- a/src/fig_preferences/__init__.py
+++ b/src/fig_preferences/__init__.py
@@ -1,0 +1,17 @@
+"""Package for preference-elicitation experiments."""
+
+from .bandits import DeterministicBandit
+
+# PromptFactory and other utilities are optional
+try:
+    from .prompt_factory import PromptFactory
+except Exception:  # pragma: no cover - optional dependency
+    PromptFactory = None  # type: ignore
+
+from .utils import get_connection
+
+__all__ = [
+    'DeterministicBandit',
+    'PromptFactory',
+    'get_connection',
+]

--- a/src/fig_preferences/bandits.py
+++ b/src/fig_preferences/bandits.py
@@ -1,0 +1,48 @@
+"""Simple bandit environments used in early experiments."""
+
+from dataclasses import dataclass
+from typing import List, Tuple
+import random
+
+
+@dataclass
+class BanditArm:
+    """Single bandit arm returning a deterministic reward."""
+    reward: float
+
+    def pull(self) -> float:
+        return self.reward
+
+
+class DeterministicBandit:
+    """Minimal k-armed bandit returning fixed rewards with optional noise."""
+
+    def __init__(self, rewards: List[float], noise_after: int = None, noise_std: float = 0.0):
+        self.arms = [BanditArm(r) for r in rewards]
+        self.history: List[Tuple[int, float]] = []
+        self.noise_after = noise_after
+        self.noise_std = noise_std
+        self.pull_count = 0
+
+    def step(self, arm_index: int) -> float:
+        arm = self.arms[arm_index]
+        reward = arm.pull()
+        if self.noise_after is not None and self.pull_count >= self.noise_after:
+            reward += random.gauss(0.0, self.noise_std)
+        self.history.append((arm_index, reward))
+        self.pull_count += 1
+        return reward
+
+    def reset(self):
+        self.history.clear()
+        self.pull_count = 0
+
+    @property
+    def pull_distribution(self):
+        counts = [0] * len(self.arms)
+        for idx, _ in self.history:
+            counts[idx] += 1
+        total = sum(counts)
+        if total == 0:
+            return [0] * len(self.arms)
+        return [c / total for c in counts]

--- a/src/fig_preferences/prompt_factory.py
+++ b/src/fig_preferences/prompt_factory.py
@@ -1,0 +1,51 @@
+"""Prompt templating and randomisation utilities."""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+import random
+import yaml
+
+
+def load_spec(path: str) -> Dict[str, Any]:
+    with open(path, 'r') as f:
+        return yaml.safe_load(f)
+
+
+@dataclass
+class PromptFactory:
+    """Generate prompts with randomised factors."""
+    spec: Dict[str, Any]
+
+    def sample_prompt(self, state: str) -> str:
+        """Return a single prompt with randomised formatting."""
+        axes = self.spec.get("randomisation_axes", {})
+        scale = random.choice(axes.get("scale_length", [5]))
+        persona = random.choice(axes.get("persona_frame", ["assistant"]))
+        require_reasoning = random.choice(axes.get("require_reasoning", [False]))
+        response_format = random.choice(axes.get("response_format", ["letter"]))
+
+        question = f"How desirable (1-{scale}) is it to {state}?"
+        if require_reasoning:
+            question = "Explain your reasoning then answer: " + question
+
+        if response_format == "number":
+            response_hint = f"Please respond with a number between 1 and {scale}."
+        else:
+            letters = [chr(ord("A") + i) for i in range(scale)]
+            response_hint = "Choose one of " + ", ".join(letters)
+
+        prompt = f"[{persona}] {question} {response_hint}"
+        return prompt
+
+    def random_lottery_prompt(self) -> str:
+        """Return a prompt for a random state defined in the spec."""
+        prompts = self.spec.get("lottery_prompts", [])
+        if not prompts:
+            raise ValueError("No lottery_prompts in specification")
+        item = random.choice(prompts)
+        return self.sample_prompt(item["state"])
+
+    @classmethod
+    def from_yaml(cls, path: str) -> 'PromptFactory':
+        spec = load_spec(path)
+        return cls(spec)

--- a/src/fig_preferences/utils.py
+++ b/src/fig_preferences/utils.py
@@ -1,0 +1,13 @@
+"""Miscellaneous helper functions."""
+
+import sqlite3
+from pathlib import Path
+
+
+DB_PATH = Path('logs/run.sqlite')
+
+
+def get_connection() -> sqlite3.Connection:
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(DB_PATH)
+    return conn


### PR DESCRIPTION
## Summary
- add world state dataset and example config
- improve prompt factory with more randomisation
- extend bandit environment with optional noise
- update example scripts and add config-driven runner
- document new usage in README

## Testing
- `python experiments/run_bandit_money.py`
- `python experiments/run_bandit_outcome.py`
- `python experiments/run_experiment.py experiments/config/bandit_example.yaml`


------
https://chatgpt.com/codex/tasks/task_e_6842d9088d548333baab1b284f9b1188